### PR TITLE
Refactor: restructure state-based UI logic in ChatChannelStrip

### DIFF
--- a/src/components/MainInterface/Strip/ChatChannelStrip/ChatChannelStrip.tsx
+++ b/src/components/MainInterface/Strip/ChatChannelStrip/ChatChannelStrip.tsx
@@ -10,15 +10,18 @@ const ChatChannelStrip: React.FC = () => {
   const selectedOrg = useSelector((state: RootState) => state.ui.selectedOrg);
   const organizations = useSelector((state: RootState) => state.user.orgs);
   const currentUser = useSelector((state: RootState) => state.user.user);
+  
 
   const [isAdding, setIsAdding] = useState(false);
   const [newTeamName, setNewTeamName] = useState("");
 
-  const org = organizations.find((o) => o === selectedOrg);
+  const org = organizations.find((o) => o.id === selectedOrg?.id);
 
   if (!org || !currentUser) return null;
 
   const authorityToCreateNewTeam = org.admins.includes(currentUser.id);
+
+
 
   const handleCreateTeam = async () => {
     const trimmed = newTeamName.trim();

--- a/src/hooks/MainRenderHooks/useInitializeApp.ts
+++ b/src/hooks/MainRenderHooks/useInitializeApp.ts
@@ -30,7 +30,6 @@ export const useInitializeApp = () => {
           socket.on("refresh_required", async () => {
             const refreshed = await fetchInitUserData();
             dispatch(setUserInitData(refreshed));
-            console.log("Refreshed data:", refreshed);
             joinChatRooms(socket, refreshed);
             await fetchAndStoreDocumentHierarchy(refreshed, dispatch);
           });

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { use, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { RootState } from "../store";
 import '../styles/MainInterface/Layout/MainLayout.css';

--- a/src/store/slices/uiSlice.ts
+++ b/src/store/slices/uiSlice.ts
@@ -24,32 +24,21 @@ const uiSlice = createSlice({
   initialState,
   reducers: {
     setSelectedOrg: (state, action: PayloadAction<Organization | null>) => {
-      console.log("old selected org", state.selectedOrg);
-      console.log("new selected org", action.payload);
       state.selectedOrg = action.payload;
       state.selectedTeam = null;
       state.selectedDocument = null;
     },
     setSelectedPeer: (state, action: PayloadAction<Peer | null>) => {
-      console.log("old selected peer", state.selectedPeer);
-      console.log("new selected peer", action.payload);
       state.selectedPeer = action.payload;
       state.selectedOrg = null;
-      //state.selectedTeam = action.payload;
     },
     setSelectedTeam: (state, action: PayloadAction<Team | null>) => {
-      console.log("old selected team", state.selectedTeam);
-      console.log("new selected team", action.payload);
       state.selectedTeam = action.payload;
     },
     setSelectedDocument: (state, action: PayloadAction<Document | null>) => {
-      console.log("old selected document", state.selectedDocument);
-      console.log("new selected document", action.payload);
       state.selectedDocument = action.payload;
     },
     setSelectedRenderMode: (state, action: PayloadAction<string>) => {
-      console.log("old selected render mode", state.selectedRenderMode);
-      console.log("new selected render mode", action.payload);
       state.selectedRenderMode = action.payload;
     },
     resetSelection: (state) => {

--- a/src/styles/MainInterface/strips/ChatChannelStrip/ChatChannelStrip.css
+++ b/src/styles/MainInterface/strips/ChatChannelStrip/ChatChannelStrip.css
@@ -3,6 +3,8 @@
     background-color: white;
     color: black;
     height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .chat-channel-title {
@@ -16,6 +18,14 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    overflow-y: auto;
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    flex: 1;
+}
+
+.chat-channel-list::-webkit-scrollbar {
+    display: none;
 }
 
 .chat-channel-item {


### PR DESCRIPTION
## 변경 사항
- `organizations.find(o => o === selectedOrg)` 를 ID 기반 비교로 수정
- selectedOrg의 객체 reference mismatch 문제 해결
- 채널 스트립이 새로 생성된 팀을 포함해 안정적으로 렌더링됨
- Organization 버튼도 안정적으로 렌더링
- AddNewTeamForm 제거, ChatChannelStrip 내에서 자체적으로 해결
